### PR TITLE
Avoid SetColorTable error message

### DIFF
--- a/R/retrieve_raster.R
+++ b/R/retrieve_raster.R
@@ -37,7 +37,7 @@ retrieve_raster <- function(layer, out_layer, overwrite = FALSE, ...){
     for(i in 1:n_layers){
       execGRASS(
         'r.out.gdal', 
-        flags = c("overwrite", "quiet"),
+        flags = c("overwrite", "quiet", "c"),
         parameters = list(
           input = layer[i],
           output = out_layer[i],
@@ -49,7 +49,7 @@ retrieve_raster <- function(layer, out_layer, overwrite = FALSE, ...){
     for(i in 1:n_layers){
       execGRASS(
         'r.out.gdal', 
-        flags = c("quiet"),
+        flags = c("quiet", "c"),
         parameters = list(
           input = layer[i],
           output = out_layer[i],


### PR DESCRIPTION
When I run the [example code for `retrieve_raster`](https://github.com/apear9/rdwplus/blob/master/R/retrieve_raster.R) I get the following error:

> ERROR 6: SetColorTable() only supported for Byte or UInt16 bands in TIFF format.

This PR adds the `c` flag to the `r.out.gdal`:

>  Do not write GDAL standard colortable
    Only applicable to Byte or UInt16 data types

https://grass.osgeo.org/grass78/manuals/r.out.gdal.html